### PR TITLE
12 floating point math

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 This project contains the simplest possible compiler, which converts simple mathematical operations into assembly language, allowing all the speed in your sums!
 
-Because this is a simple project it operates solely upon integers, and
-provides only the following primitives:
+Because this is a simple project it provides only a small number of primitives:
 
 * `+` - Plus
 * `-` - Minus
@@ -11,7 +10,10 @@ provides only the following primitives:
 * `/` - Divide
 * `^` - Raise to a power
 * `%` - Modulus
+* `sin`
+* `cos`
 
+Operations may return floating-point numbers, and negative numbers though, which is nice to see.
 
 
 # Installation
@@ -120,22 +122,14 @@ I believe that means we should be OK to store 64-bit numbers.
 
 ## Possible Expansion?
 
-The obvious thing to improve in this compiler is to add support for
-floating-point operations.  Adding support for floating point operations would allow the following program to produce a valid result:
+The obvious thing to improve in this compiler is to add support for more floating-point operations, such as square-roots, and similar.
 
-      3 2 /
+At the moment basic-support is present, allowing calcuations such as this to produce the correct result:
 
-We'd also gain the ability to run Sin, Cos, Tan, etc.  Though that would
-require the lexer to be updated to allow:
-
-      3 cos 12 +
-
-(i.e. "`12 + cos(3)`")
-
-The following brief page documents the approach required, although the devil will be in the details, as always:
-
-* https://en.wikibooks.org/wiki/X86_Assembly/Floating_Point
-
+* `3 2 /`
+  * Correctly returns `1.5`
+* `1 3 / 9 *`
+  * Correctly returns 1/3 * 9 == `3`.
 
 
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ Because this is a simple project it provides only a small number of primitives:
 * `%` - Modulus
 * `sin`
 * `cos`
+* `tan`
+* `sqrt`
 
 Operations may return floating-point numbers, and negative numbers though, which is nice to see.
 
@@ -122,7 +124,7 @@ I believe that means we should be OK to store 64-bit numbers.
 
 ## Possible Expansion?
 
-The obvious thing to improve in this compiler is to add support for more floating-point operations, such as square-roots, and similar.
+The obvious thing to improve in this compiler is to add support for more floating-point operations.
 
 At the moment basic-support is present, allowing calcuations such as this to produce the correct result:
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -97,6 +97,17 @@ func (c *Compiler) Compile() error {
 	}
 
 	//
+	// Get the last token
+	//
+	if len(c.tokens) > 1 {
+		len := len(c.tokens)
+		end := c.tokens[len-1]
+		if end.Type == token.NUMBER {
+			return fmt.Errorf("Program ends with a number, which is invalid!")
+		}
+	}
+
+	//
 	// No error.
 	//
 	return nil
@@ -235,7 +246,6 @@ func (c *Compiler) Output() (string, error) {
 			// N ^ 3 -> N * N * N
 			// ..
 			//
-			fmt.Printf("# ^ %s\n", i)
 			switch i {
 			case "0":
 				// store zero

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -183,6 +183,32 @@ func (c *Compiler) Output() (string, error) {
 
 		case token.MOD:
 
+			// ensure that "i" is an int
+			if strings.Contains(i, ".") {
+				return "", fmt.Errorf("Can only run a modulus operation with an integer")
+			}
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+			// found to float
+			operations = append(operations, `frndint`)
+			// store back
+			operations = append(operations, `fistp qword ptr [result]`) // set that value in rax
+			operations = append(operations, `mov rax, qword ptr [result]`)
+
+			// do the modulus.  magic.
+			operations = append(operations, `xor rdx, rdx`)
+			operations = append(operations, `mov rbx, `+i)
+			operations = append(operations, `cqo`)
+			operations = append(operations, `div rbx`)
+			operations = append(operations, `mov rax, rdx`)
+
+			// store back the result of eax into the address, appropriately
+			operations = append(operations, `mov qword ptr[result], rax`)
+			operations = append(operations, `fild qword ptr [result]
+`)
+			operations = append(operations, `fstp qword ptr [result]`)
+
 		case token.MINUS:
 
 			// load the (current) result

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -63,7 +63,7 @@ func (c *Compiler) Compile() error {
 	//
 	// If the first token isn't a number we're in trouble
 	//
-	if c.tokens[0].Type != token.INT {
+	if c.tokens[0].Type != token.NUMBER{
 		return (fmt.Errorf("We expected the program to begin with an integer!\n"))
 	}
 

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,8 +1,30 @@
+// compiler contains our simple compiler.
+//
+// In brief it uses the lexer to tokenize the expression, and outputs
+// a simple assembly language program.
+//
+// There are only two minor complications:
+//
+//  1.  We store all the input-floats in the data-area of the program.
+//      These require escaping for uniqueness purposes.
+//
+//  2.  We output different instructions based on the operator.
+//
+//  we could do better with an intermediary form, concatenating small
+// segments of code, and avoiding the frequent loads from the `result`
+// location.
+//
+// That said this is a toy, and will remain a toy, so I can live with
+// these problems.
+//
+
 package compiler
 
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
 	"text/template"
 
 	"github.com/skx/math-compiler/lexer"
@@ -43,13 +65,20 @@ func (c *Compiler) Compile() error {
 	// First of all populate that `program` array with our tokens.
 	//
 	for {
+		// Get the next token.
 		tok := lexed.NextToken()
+
+		// If end of stream then break.
 		if tok.Type == token.EOF {
 			break
 		}
+
+		// If error then abort.
 		if tok.Type == token.ERROR {
 			return (fmt.Errorf("Error parsing input; token.ERROR returned from the lexer"))
 		}
+
+		// Otherwise append the token to our program.
 		c.tokens = append(c.tokens, tok)
 	}
 
@@ -63,21 +92,8 @@ func (c *Compiler) Compile() error {
 	//
 	// If the first token isn't a number we're in trouble
 	//
-	if c.tokens[0].Type != token.NUMBER{
-		return (fmt.Errorf("We expected the program to begin with an integer!\n"))
-	}
-
-	//
-	// The program should have:
-	//   starting-value
-	//   NUMBER OPERATOR..
-	//   NUMBER OPERATOR..
-	//   ..
-	//   NUMBER OPERATOR..
-	//
-	// That means the program should always have an odd-length
-	if len(c.tokens)%2 == 0 {
-		return (fmt.Errorf("The program should always have an odd-length"))
+	if c.tokens[0].Type != token.NUMBER {
+		return (fmt.Errorf("We expected the program to begin with a numeric thing!\n"))
 	}
 
 	//
@@ -118,6 +134,21 @@ func (c *Compiler) Output() (string, error) {
 	var operations []string
 
 	//
+	// Constants we come across.
+	//
+	// Rather than placing the integers in-line we're storing them
+	// in the constant area.  This gives us a level of indirection,
+	// but it simpler to reason about.
+	//
+	// Note that if we see "3 + 4 + 3 + 4" we only store each of
+	// the constants once each.  So we have a map here, key is the
+	// value of the constant, and `bool` to record that we found it.
+	//
+	// Later we'll output just the unique keys.
+	//
+	constants := make(map[string]bool)
+
+	//
 	// Temporary-storage for the number we're operating upon next.
 	//
 	var i string
@@ -126,107 +157,102 @@ func (c *Compiler) Output() (string, error) {
 	// Walk over the array of tokens - skipping the first one,
 	// which is our initial value.
 	//
-	for offset, ent := range c.tokens[1:] {
+	for _, ent := range c.tokens[1:] {
 
-		//
-		// If we have no number then save it.
-		//
-		if i == "" {
-			// number
-			i = ent.Literal
-			continue
-		}
-
-		//
-		// The number is already set, so we're now expecting
-		// an operator which will be applied to it.
-		//
 		switch ent.Type {
 
+		case token.NUMBER:
+			// Save the literal value away
+			i = ent.Literal
+
+			// Record that this constant is set.
+			constants[ent.Literal] = true
+
 		case token.PLUS:
-			operations = append(operations, `add rax, `+i)
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// add the constant
+			constant := c.escapeConstant(i)
+			operations = append(operations, `fadd qword ptr [`+constant+`]`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
 
 		case token.MOD:
 
-			//
-			// Modulus is a cheat as `div` will handle
-			// setting the remainder in `edx`.
-			//
-			// In brief we need:
-			//
-			//  xor rdx,rdx      ;; clear lower-bits
-			//  mv rbx, val      ;; store
-			//  div [eax], [rbx] ;; divide
-			//  mov eax, rdx     ;; move result
-			//
-			operations = append(operations, `xor rdx, rdx`)
-			operations = append(operations, `mov rbx, `+i)
-			operations = append(operations, `cqo`)
-			operations = append(operations, `div rbx`)
-			operations = append(operations, `mov rax, rdx`)
+			return "", fmt.Errorf("token.MOD - not implemented")
 
 		case token.MINUS:
-			operations = append(operations, `sub rax,`+i)
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// subtract the constant
+			constant := c.escapeConstant(i)
+			operations = append(operations, `fsub qword ptr [`+constant+`]`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
 
 		case token.POWER:
+			return "", fmt.Errorf("token.POWER - not implemented")
 
-			//
-			// N ^ 0 -> 0
-			// N ^ 1 -> N
-			// N ^ 2 -> N * N
-			// N ^ 3 -> N * N * N
-			// ..
-			//
-			switch i {
-			case "0":
-				operations = append(operations, `xor rax, rax`)
-			case "1":
-				// nop
-			default:
-				//
-				// We'll want to output a loop which
-				// means we need a unique label
-				//
-				// We generate the label ID as the offset of
-				// the statement we're generating in our input
-				//
-				label := fmt.Sprintf("label_%d", offset)
-
-				//
-				// Output the loop to calculate the power.
-				//
-				operations = append(operations, `mov rcx, `+i)
-				operations = append(operations, `mov ebx, eax`)
-				operations = append(operations, `dec rcx`)
-				operations = append(operations, label+":")
-				operations = append(operations, `  mul ebx`)
-				operations = append(operations, `  dec rcx`)
-				operations = append(operations, `  jnz `+label)
-			}
 		case token.SLASH:
-			// Handle a division by zero at run-time.
-			// We could catch it at generation-time, just as well..
+
 			if i == "0" {
-				operations = append(operations, `jmp div_by_zero`)
-			} else {
-				operations = append(operations, `mov ebx, `+i)
-				operations = append(operations, `cqo`)
-				operations = append(operations, `div ebx`)
+				fmt.Printf("Division by zero!")
+				os.Exit(1)
+
 			}
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// divide by the constant
+			constant := c.escapeConstant(i)
+			operations = append(operations, `fdiv qword ptr [`+constant+`]`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
 
 		case token.ASTERISK:
-			operations = append(operations, `mov ebx, `+i)
-			operations = append(operations, `mul ebx`)
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// multiply by the constant
+			constant := c.escapeConstant(i)
+			operations = append(operations, `fmul qword ptr [`+constant+`]`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
+
+		case token.SIN:
+
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// run the sin
+			operations = append(operations, `fsin`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
+
+		case token.COS:
+			// load the (current) result
+			operations = append(operations, `fld qword ptr [result]`)
+
+			// run the cos
+			operations = append(operations, `fcos`)
+
+			// store back in the result store.
+			operations = append(operations, `fstp qword ptr [result]`)
 
 		default:
 			return "", fmt.Errorf("Invalid program - expected operator, but found %v\n", ent)
 		}
-
-		//
-		// Next time around the loop we'll be looking for
-		// a number, rather than an operator.
-		//
-		i = ""
 	}
 
 	//
@@ -236,8 +262,14 @@ func (c *Compiler) Output() (string, error) {
 	// our output-template.
 	//
 	type Assembly struct {
-		Start      string
+		// The starting value.
+		Start string
+
+		// The operations we carry out.
 		Operations []string
+
+		// Any constants we load.
+		Constants []string
 	}
 
 	//
@@ -256,33 +288,44 @@ func (c *Compiler) Output() (string, error) {
 	out.Operations = operations
 
 	//
+	// The constants
+	//
+	for key, _ := range constants {
+		out.Constants = append(out.Constants, key)
+	}
+
+	//
 	// This is the template we'll output.
 	//
-	assembly := `.intel_syntax noprefix
+	assembly := `
+.intel_syntax noprefix
 .global main
 
+# Data-section: Contains the format-string for our output message,
+#               the starting value, and any constants we use.
 .data
-format: .asciz "Division by zero\n"
-result: .asciz "Result %d\n"
+result: .double {{.Start}}
+fmt:   .asciz "Result %g\n"
+{{range .Constants}}const_{{.}}: .double {{.}}
+{{end}}
 
 main:
- mov rax, {{.Start}}
+        push	rbp
+
 {{range .Operations}} {{.}}
 {{end}}
- lea rdi,result
- mov rsi, rax
- xor rax, rax
- call printf
- xor rax, rax
- ret
 
-div_by_zero:
- push rbx
- lea  rdi,format
- call printf
- pop rbx
- mov rax, 0
- ret
+        # print the result
+        lea rdi,fmt
+        movq rax, 1
+        movq xmm0, [result]
+        call printf
+
+        # clean and exit
+        pop	rbp
+        xor rax, rax
+        ret
+
 `
 
 	//
@@ -301,4 +344,23 @@ div_by_zero:
 
 	return buf.String(), nil
 
+}
+
+// escapeConstant converts a floating-point number such as
+// "1.2", or "-1.3" into a constant value that can be embedded
+// safely into our generated assembly-language file.
+func (c *Compiler) escapeConstant(input string) string {
+
+	// Convert "3.0" to "const_3.0"
+	s, err := strconv.ParseFloat(input, 32)
+
+	if err != nil {
+		fmt.Printf("Failed to parse '%s' into a float\n", input)
+		fmt.Printf("%s\n", err.Error())
+	}
+
+	if s < 0 {
+		return fmt.Sprintf("const_neg_%s", input)
+	}
+	return fmt.Sprintf("const_%s", input)
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -20,11 +20,10 @@ func TestBogusInput(t *testing.T) {
 		"3 5 $",
 
 		// program with a missing operator
-		//TODO		"3 3",
+		"3 3",
 
 		// Again
-		//TODO TODO	"3 4 + 3",
-
+		"3 4 + 3",
 	}
 
 	for _, test := range tests {

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -20,10 +20,11 @@ func TestBogusInput(t *testing.T) {
 		"3 5 $",
 
 		// program with a missing operator
-		"3 3",
+		//TODO		"3 3",
 
 		// Again
-		"3 4 + 3",
+		//TODO TODO	"3 4 + 3",
+
 	}
 
 	for _, test := range tests {
@@ -82,7 +83,6 @@ func TestValidOutput(t *testing.T) {
 		"2 0 ^",  // N ^ 0 is a special case
 		"2 1 ^",  // N ^ 1 is a special case
 		"2 12 ^", // N ^ 12 is NOT a special case!
-		"3 0 /",  // division by zero
 	}
 
 	for _, test := range tests {
@@ -117,12 +117,12 @@ func TestValidOutput(t *testing.T) {
 //   "compile".
 //   "output".
 //
-// We just look for errors here.
-//
 func TestInvalidOutput(t *testing.T) {
 
 	tests := []string{
-		"1 2 - 3 3",
+		"3 0 /",
+		"3 3.3 %",
+		"2 3.4 ^",
 	}
 
 	for _, test := range tests {
@@ -133,14 +133,13 @@ func TestInvalidOutput(t *testing.T) {
 		// compile
 		err := c.Compile()
 		if err != nil {
-			t.Errorf("We didn't expect an error compiling our program, but found one %s", err.Error())
+			t.Errorf("We didn't expect an error compiling an invalid program, but found one %s", err.Error())
 		}
 
 		// output
 		_, err = c.Output()
 		if err == nil {
-			t.Errorf("We expected an error outputing our invalid program, but found none")
+			t.Errorf("We expected an error outputing an invalid program, but found none")
 		}
-
 	}
 }

--- a/lexer/lexer.go
+++ b/lexer/lexer.go
@@ -52,7 +52,7 @@ func (l *Lexer) NextToken() token.Token {
 
 			// read the number
 			tok.Literal = l.readNumber()
-			tok.Type = token.INT
+			tok.Type = token.NUMBER
 
 			tok.Literal = "-" + tok.Literal
 
@@ -110,7 +110,7 @@ func (l *Lexer) readDecimal() token.Token {
 	// Read an integer-number.
 	//
 	integer := l.readNumber()
-	return token.Token{Type: token.INT, Literal: integer}
+	return token.Token{Type: token.NUMBER, Literal: integer}
 }
 
 // peek character

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -32,6 +32,32 @@ func TestParseNumbers(t *testing.T) {
 	}
 }
 
+// Trivial test of parsing floats.
+func TestParseFloats(t *testing.T) {
+	input := `3.14 4.3 -1.7 -2.13`
+
+	tests := []struct {
+		expectedType    token.TokenType
+		expectedLiteral string
+	}{
+		{token.NUMBER, "3.14"},
+		{token.NUMBER, "4.3"},
+		{token.NUMBER, "-1.7"},
+		{token.NUMBER, "-2.13"},
+		{token.EOF, ""},
+	}
+	l := New(input)
+	for i, tt := range tests {
+		tok := l.NextToken()
+		if tok.Type != tt.expectedType {
+			t.Fatalf("tests[%d] - tokentype wrong, expected=%q, got=%q", i, tt.expectedType, tok.Type)
+		}
+		if tok.Literal != tt.expectedLiteral {
+			t.Fatalf("tests[%d] - Literal wrong, expected=%q, got=%q", i, tt.expectedLiteral, tok.Literal)
+		}
+	}
+}
+
 // Trivial test of the parsing of operators.
 func TestParseOperators(t *testing.T) {
 	input := `+ - * / % ^ -`

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -14,10 +14,10 @@ func TestParseNumbers(t *testing.T) {
 		expectedType    token.TokenType
 		expectedLiteral string
 	}{
-		{token.INT, "3"},
-		{token.INT, "43"},
-		{token.INT, "-17"},
-		{token.INT, "-3"},
+		{token.NUMBER, "3"},
+		{token.NUMBER, "43"},
+		{token.NUMBER, "-17"},
+		{token.NUMBER, "-3"},
 		{token.EOF, ""},
 	}
 	l := New(input)
@@ -74,7 +74,7 @@ func TestParseBogus(t *testing.T) {
 		{token.ERROR, "e"},
 		{token.ERROR, "v"},
 		{token.ERROR, "e"},
-		{token.INT, "3"},
+		{token.NUMBER, "3"},
 		{token.EOF, ""},
 	}
 	l := New(input)

--- a/lexer/lexer_test.go
+++ b/lexer/lexer_test.go
@@ -95,11 +95,7 @@ func TestParseBogus(t *testing.T) {
 		expectedType    token.TokenType
 		expectedLiteral string
 	}{
-		{token.ERROR, "s"},
-		{token.ERROR, "t"},
-		{token.ERROR, "e"},
-		{token.ERROR, "v"},
-		{token.ERROR, "e"},
+		{token.ERROR, "steve"},
 		{token.NUMBER, "3"},
 		{token.EOF, ""},
 	}

--- a/test.sh
+++ b/test.sh
@@ -43,18 +43,18 @@ test_compile '10 2 -' 8
 test_compile '10 2 /' 5
 
 # modulus
-#test_compile  '1 4 %' 1
-#test_compile  '2 4 %' 2
-#test_compile  '3 4 %' 3
-#test_compile  '4 4 %' 0
-#test_compile  '5 4 %' 1
-#test_compile  '6 4 %' 2
-#test_compile  '7 4 %' 3
-#test_compile  '8 4 %' 0
-#test_compile  '9 4 %' 1
-#test_compile '10 4 %' 2
-#test_compile '11 4 %' 3
-#test_compile '12 4 %' 0
+test_compile  '1 4 %' 1
+test_compile  '2 4 %' 2
+test_compile  '3 4 %' 3
+test_compile  '4 4 %' 0
+test_compile  '5 4 %' 1
+test_compile  '6 4 %' 2
+test_compile  '7 4 %' 3
+test_compile  '8 4 %' 0
+test_compile  '9 4 %' 1
+test_compile '10 4 %' 2
+test_compile '11 4 %' 3
+test_compile '12 4 %' 0
 
 # powers of two - the manual-way
 test_compile '2 2 *' 4

--- a/test.sh
+++ b/test.sh
@@ -43,18 +43,18 @@ test_compile '10 2 -' 8
 test_compile '10 2 /' 5
 
 # modulus
-test_compile  '1 4 %' 1
-test_compile  '2 4 %' 2
-test_compile  '3 4 %' 3
-test_compile  '4 4 %' 0
-test_compile  '5 4 %' 1
-test_compile  '6 4 %' 2
-test_compile  '7 4 %' 3
-test_compile  '8 4 %' 0
-test_compile  '9 4 %' 1
-test_compile '10 4 %' 2
-test_compile '11 4 %' 3
-test_compile '12 4 %' 0
+#test_compile  '1 4 %' 1
+#test_compile  '2 4 %' 2
+#test_compile  '3 4 %' 3
+#test_compile  '4 4 %' 0
+#test_compile  '5 4 %' 1
+#test_compile  '6 4 %' 2
+#test_compile  '7 4 %' 3
+#test_compile  '8 4 %' 0
+#test_compile  '9 4 %' 1
+#test_compile '10 4 %' 2
+#test_compile '11 4 %' 3
+#test_compile '12 4 %' 0
 
 # powers of two - the manual-way
 test_compile '2 2 *' 4
@@ -72,7 +72,7 @@ inp="2 2 *"
 for i in $(seq 1 22 ) ; do
     inp="${inp} 2 *"
 done
-test_compile "$inp" 16777216
+test_compile "$inp" 1.67772e+07
 
 
 # powers of two - the simple way
@@ -86,12 +86,12 @@ test_compile '2 6 ^'          64
 test_compile '2 7 ^'         128
 test_compile '2 8 ^'         256
 test_compile '2 16 ^'      65536
-test_compile '2 30 ^' 1073741824
+test_compile '2 30 ^' 1.07374e+09
 
 
 # Note we're operating on integers, so these are "correct".
-test_compile '3 2 /' 1
-test_compile '5 2 /' 2
+test_compile '3 2 /' 1.5
+test_compile '5 2 /' 2.5
 
 
 exit 0

--- a/token/token.go
+++ b/token/token.go
@@ -13,7 +13,7 @@ type Token struct {
 const (
 	EOF      = "EOF"
 	ERROR    = "ERROR"
-	INT      = "INT"
+	NUMBER   = "NUMBER"
 	PLUS     = "+"
 	MINUS    = "-"
 	ASTERISK = "*"

--- a/token/token.go
+++ b/token/token.go
@@ -27,15 +27,20 @@ const (
 	POWER = "^" // todo
 
 	// complex operations
-	COS = "cos"
-	SIN = "sin"
+	COS  = "cos"
+	SIN  = "sin"
+	SQRT = "sqrt"
+	TAN  = "tan"
+
 	// TAN = "tan" // todo / impossible?
 )
 
 // reversed keywords
 var keywords = map[string]TokenType{
-	"cos": COS,
-	"sin": SIN,
+	"cos":  COS,
+	"sin":  SIN,
+	"sqrt": SQRT,
+    "tan":  TAN,
 }
 
 // LookupIdentifier used to determinate whether identifier is keyword nor not

--- a/token/token.go
+++ b/token/token.go
@@ -11,13 +11,37 @@ type Token struct {
 
 // pre-defined TokenType
 const (
-	EOF      = "EOF"
-	ERROR    = "ERROR"
-	NUMBER   = "NUMBER"
+	EOF    = "EOF"
+	ERROR  = "ERROR"
+	NUMBER = "NUMBER"
+	IDENT  = "IDENT"
+
+	// simple operations
 	PLUS     = "+"
 	MINUS    = "-"
 	ASTERISK = "*"
 	SLASH    = "/"
-	MOD      = "%"
-	POWER    = "^"
+
+	// advanced operations
+	MOD   = "%" // todo
+	POWER = "^" // todo
+
+	// complex operations
+	COS = "cos"
+	SIN = "sin"
+	// TAN = "tan" // todo / impossible?
 )
+
+// reversed keywords
+var keywords = map[string]TokenType{
+	"cos": COS,
+	"sin": SIN,
+}
+
+// LookupIdentifier used to determinate whether identifier is keyword nor not
+func LookupIdentifier(identifier string) TokenType {
+	if tok, ok := keywords[identifier]; ok {
+		return tok
+	}
+	return ERROR
+}

--- a/token/token_test.go
+++ b/token/token_test.go
@@ -1,0 +1,18 @@
+package token
+
+import (
+	"testing"
+)
+
+// Test looking up values succeeds, then fails
+func TestLookup(t *testing.T) {
+
+	for key, val := range keywords {
+
+		// Obviously this will pass.
+		if LookupIdentifier(string(key)) != val {
+			t.Errorf("Lookup of %s failed", key)
+		}
+
+	}
+}


### PR DESCRIPTION
Work in progress to support floating-point maths.

The rough plan is:

* [x] Use `token.NUMBER` not `token.INT` - Since we want to store floats in addition to ints.
* [x] Parse integers AND floats in our lexer - Since users will write "3.4 4.7 +", etc.
* [x] Update our compiler to allow storing constants
  * 3.0  -> const_3_0: dq 3.0
* [x] Update our template to use floating-point operations for the core primitives:
 * [x] `add` (`+`)
 * [x] `sub` (`-`)
 * [x] `div` (`/`)
 * [x] `mul` (`*`)

* [x] Finally add more primitives
  * [x] `mod` (`%`)
  * [x] `pow` (`^`)
  * [x] `sin`
  * [x] `cos`
* [ ] Optionally allow `pi`
  * Since there is a the ` fldpi` instruction we could use.

   
Once complete this pull-request will close #12.