### PR TITLE
22 api cleanup

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -85,7 +85,29 @@ func (c *Compiler) SetDebug(val bool) {
 // Compile converts the input program into a collection of
 // AMD64-assembly language.
 func (c *Compiler) Compile() (string, error) {
-	return "", nil
+
+	//
+	// Parse the program into a series of statements, etc.
+	//
+	// At this point there might be errors.  If so report them,
+	// and terminate.
+	//
+	err := c.tokenize()
+	if err != nil {
+		return "", err
+	}
+
+	//
+	// Convert the parsed-tokens to in internal-form.
+	//
+	c.makeinternalform()
+
+	//
+	// Now generate the output assembly
+	//
+	out := c.output()
+
+	return out, nil
 }
 
 // tokenize populates our internal list of tokens, as a result of

--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -1,15 +1,12 @@
-// compiler contains our simple compiler.
+// The compiler-package contains the core of our compiler.
 //
-// In brief it uses the lexer to tokenize the expression, then we convert
-// that series of tokens into an "internal representation" which is pretty
-// much things like:
+// In brief we go through a three-step process:
 //
-//    push_int 3
-//    push_int 4
-//    Add
+//  1.  It use the lexer to tokenize the expression.
 //
-// We iterate over this simple representation and output a block of code
-// for each.
+//  2.  Convert our program from a series of tokens to an internal form.
+//
+//  3.  Walk our internal form, generating output for each block.
 //
 // There are only one minor complication - storing all the input-floats
 // in the data-area of the program.  These require escaping for uniqueness
@@ -65,6 +62,15 @@ type Compiler struct {
 	instructions []instructions.Instruction
 }
 
+//
+// Our public API consists of the three functions:
+//  New
+//  SetDebug
+//  Compile
+//
+// The rest of the code is an implementation detail.
+//
+
 // New creates a new compiler, given the expression in the constructor.
 func New(input string) *Compiler {
 	c := &Compiler{expression: input, constants: make(map[string]bool), debug: false}
@@ -76,12 +82,18 @@ func (c *Compiler) SetDebug(val bool) {
 	c.debug = val
 }
 
-// Tokenize populates our internal list of tokens, as a result of
+// Compile converts the input program into a collection of
+// AMD64-assembly language.
+func (c *Compiler) Compile() (string, error) {
+	return "", nil
+}
+
+// tokenize populates our internal list of tokens, as a result of
 // lexing the input string.
 //
 // There is some error-handling to ensure that the program looks
 // somewhat reasonable.
-func (c *Compiler) Tokenize() error {
+func (c *Compiler) tokenize() error {
 
 	//
 	// Create the lexer, which will parse our expression.
@@ -152,11 +164,11 @@ func (c *Compiler) Tokenize() error {
 	return nil
 }
 
-// InternalForm converts our series of tokens (i.e. the lexed expression) into
-// an an intermediary form, collecting constants as they are discovered.
+// makeinternalform converts our series of tokens (i.e. the lexed expression)
+// into an an intermediary form, collecting constants as they are discovered.
 //
 // This is the middle-step before generating our assembly-language program.
-func (c *Compiler) InternalForm() {
+func (c *Compiler) makeinternalform() {
 
 	//
 	// Walk our tokens.
@@ -248,8 +260,9 @@ func (c *Compiler) InternalForm() {
 
 }
 
-// Output writes our program to stdout
-func (c *Compiler) Output() (string, error) {
+// output generates the output, joining a header, a footer, and the
+// writes our program to stdout
+func (c *Compiler) output() string {
 
 	//
 	// The header.
@@ -423,5 +436,5 @@ print_msg_and_exit:
 
 `
 
-	return header + body + footer, nil
+	return header + body + footer
 }

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -28,7 +28,7 @@ func TestBogusInput(t *testing.T) {
 
 	for _, test := range tests {
 		c := New(test)
-		err := c.Tokenize()
+		err := c.tokenize()
 		if err == nil {
 			t.Errorf("We expected an error handling '%s', but got none!", test)
 		}
@@ -58,19 +58,16 @@ func TestValidPrograms(t *testing.T) {
 		c := New(test)
 
 		// tokenize
-		err := c.Tokenize()
+		err := c.tokenize()
 		if err != nil {
 			t.Errorf("We didn't expect an error tokenizing a valid program, but found one %s", err.Error())
 		}
 
 		// convert to internal form
-		c.InternalForm()
+		c.makeinternalform()
 
 		// output the text
-		_, err = c.Output()
-		if err != nil {
-			t.Errorf("We didn't expect an error generating our assembly %s", err.Error())
-		}
+		_ = c.output()
 	}
 }
 
@@ -108,17 +105,13 @@ func TestValidOutput(t *testing.T) {
 		c := New(test)
 
 		// compile
-		err := c.Tokenize()
+		err := c.tokenize()
 		if err != nil {
 			t.Errorf("We didn't expect an error compiling a valid program, but found one %s", err.Error())
 		}
 
 		// output
-		out := ""
-		out, err = c.Output()
-		if err != nil {
-			t.Errorf("We didn't expect an error outputing a valid program, but found one %s", err.Error())
-		}
+		out := c.output()
 
 		// sanity-check
 		if !strings.Contains(out, "main") {
@@ -136,17 +129,16 @@ func TestDebug(t *testing.T) {
 	c.SetDebug(true)
 
 	// tokenize
-	err := c.Tokenize()
+	err := c.tokenize()
 	if err != nil {
 		t.Errorf("We didn't expect an error tokenizing a valid program, but found one %s", err.Error())
 	}
 
 	// convert to internal form
-	c.InternalForm()
+	c.makeinternalform()
 
 	// output the text
-	var out string
-	out, err = c.Output()
+	out := c.output()
 	if err != nil {
 		t.Errorf("We didn't expect an error generating our assembly %s", err.Error())
 	}

--- a/compiler/compiler_test.go
+++ b/compiler/compiler_test.go
@@ -51,6 +51,9 @@ func TestValidPrograms(t *testing.T) {
 		"10 sqrt",
 		"10 dup +",
 		"10 3 swap -",
+		"pi pi *",
+		"e pi *",
+		"-2 abs",
 	}
 
 	for _, test := range tests {
@@ -68,6 +71,37 @@ func TestValidPrograms(t *testing.T) {
 
 		// output the text
 		_ = c.output()
+	}
+}
+
+// Test some valid programs, with the shortcut
+func TestValidProgramsShortcut(t *testing.T) {
+
+	tests := []string{
+		"1 2 -",
+		"3 4 +",
+		"5 7 *",
+		"9 3 /",
+		"10 5 %",
+		"2 8 ^",
+		"3 sin",
+		"4 cos",
+		"5 tan",
+		"10 sqrt",
+		"10 dup +",
+		"10 3 swap -",
+		"pi pi *",
+		"e pi *",
+		"-2 abs",
+	}
+
+	for _, test := range tests {
+
+		c := New(test)
+		_, err := c.Compile()
+		if err != nil {
+			t.Errorf("Unexpected error compiling program: %s", err.Error())
+		}
 	}
 }
 

--- a/main.go
+++ b/main.go
@@ -51,37 +51,17 @@ func main() {
 	}
 
 	//
-	// Parse the program into a series of statements, etc.
+	// Compile
 	//
-	// At this point there might be errors.  If so report them,
-	// and terminate.
-	//
-	err := comp.Tokenize()
+	out, err := comp.Compile()
 	if err != nil {
-		fmt.Printf("There was an error compiling the input expression:\n")
-		fmt.Printf("%s\n", err.Error())
+		fmt.Printf("Error compiling: %s\n", err.Error())
 		os.Exit(1)
 	}
 
 	//
-	// Convert the parsed-tokens to in internal-form.
-	//
-	comp.InternalForm()
-
-	//
-	// Now generate the output assembly
-	//
-	var out string
-	out, err = comp.Output()
-	if err != nil {
-		fmt.Printf("Error generating output from program:\n")
-		fmt.Printf("%s\n", err.Error())
-		os.Exit(1)
-	}
-
-	//
-	// If we're not compiling then we just write the program to STDOUT,
-	// then terminate.
+	// If we're not compiling the assembly language text which was
+	// produced then we just write the program to STDOUT, and terminate.
 	//
 	if *compile == false {
 		fmt.Printf("%s", out)


### PR DESCRIPTION
Cleanup our API, so the caller only needs to call:

* `New("expression")`
* `SetDebug(bool)`
* `Compile()`

This closes #22 
