### PR TITLE
29 catch overflow

### DIFF
--- a/compiler/compiler.go
+++ b/compiler/compiler.go
@@ -325,6 +325,7 @@ func (c *Compiler) output() string {
         int: .double 0.0
         fmt: .asciz "Result %g\n"
    div_zero: .asciz "Attempted division by zero.  Aborting\n"
+   overflow: .asciz "Overflow - value out of range.  Aborting\n"
   stack_err: .asciz "Insufficient entries on the stack.  Aborting\n"
  stack_full: .asciz "Too many entries remaining on the stack.  Aborting\n"
 `
@@ -444,6 +445,13 @@ main:
 #
 division_by_zero:
         lea rdi,div_zero
+        jmp print_msg_and_exit
+
+#
+# This is hit when a register is too small to hold a value.
+#
+register_overflow:
+        lea rdi,overflow
         jmp print_msg_and_exit
 
 

--- a/compiler/generator.go
+++ b/compiler/generator.go
@@ -34,7 +34,7 @@ func (c *Compiler) escapeConstant(input string) string {
 // run an ABS-operation, and store the result back on the stack.
 func (c *Compiler) genAbs() string {
 	return `
-        # [Abs]
+        # [ABS]
         # ensure there are at least one argument on the stack
         mov rax, qword ptr [depth]
         cmp rax, 1
@@ -136,7 +136,7 @@ func (c *Compiler) genDup() string {
 // run a factorial-operation, and store the result back on the stack.
 func (c *Compiler) genFactorial(i int) string {
 	text := `
-        # [Factorial]
+        # [FACTORIAL]
         # ensure there are at least one argument on the stack
         mov rax, qword ptr [depth]
         cmp rax, 1
@@ -164,6 +164,10 @@ func (c *Compiler) genFactorial(i int) string {
 again_#ID:
         # rax = rax * rcx
         imul rax, rcx
+
+        # value too big?
+        jo register_overflow
+
         dec rcx
         jnz again_#ID
 
@@ -379,6 +383,10 @@ none_one_#ID:
 again_#ID:
            # rax = rax * rcx (which is the original value we started with)
            imul rax,rcx
+
+           # value too big?
+           jo register_overflow
+
            dec rbx
            jnz again_#ID
 
@@ -426,7 +434,7 @@ func (c *Compiler) genPush(value string) string {
 // run a sin-operation, and store the result back on the stack.
 func (c *Compiler) genSin() string {
 	return `
-        # [Sin]
+        # [SIN]
         # ensure there are at least one argument on the stack
         mov rax, qword ptr [depth]
         cmp rax, 1
@@ -453,10 +461,12 @@ func (c *Compiler) genSin() string {
 // push them back, in the other order.
 func (c *Compiler) genSwap() string {
 	return `
+        # [SWAP]
         pop rax
         pop rbx
         push rax
         push rbx
+        # stack size didn't change; popped two, pushed two.
 `
 }
 
@@ -464,6 +474,7 @@ func (c *Compiler) genSwap() string {
 // run a tan-operation, and store the result back on the stack.
 func (c *Compiler) genTan() string {
 	return `
+        # [TAN]
         # pop one value
         pop rax
         mov qword ptr [a], rax

--- a/test.sh
+++ b/test.sh
@@ -113,6 +113,7 @@ test_compile '2 7 ^'         128
 test_compile '2 8 ^'         256
 test_compile '2 16 ^'      65536
 test_compile '2 30 ^' 1.07374e+09
+test_compile '2 300 ^' 'Overflow - value out of range.  Aborting' 'full'
 
 # factorials
 test_compile '-3 !'             0
@@ -124,6 +125,7 @@ test_compile '4 !'             24
 test_compile '5 !'            120
 test_compile '6 !'            720
 test_compile '5 5 + !' 3.6288e+06  # 3628800
+test_compile '3 300 !' 'Overflow - value out of range.  Aborting' 'full'
 
 # division
 test_compile '3 2 /' 1.5


### PR DESCRIPTION
This pull-request closes #29, by detecting register overflows - i.e. handling of numbers that are too big - in the power (`^`) operator and the factorial operator (`!`).

(Ideally we'd have support for all our operations.)